### PR TITLE
Support single-module chunks where __webpack_require__ isn't defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,8 +6,9 @@ function WebpackUpdatePublicPathPlugin(options) {
 function updatePublicPath(path, source) {
     var newSource = [];
     newSource.push(source);
-    newSource.push('');
-    newSource.push('__webpack_require__.p = ' + path + ';');
+    newSource.push('if( typeof __webpack_require__ !== "undefined" ) {');
+    newSource.push('    __webpack_require__.p = ' + path + ';');
+    newSource.push('}');
 
     return newSource.join('\n');
 }


### PR DESCRIPTION
__webpack_require__ isnt defined when there is only one module, so just protect against that case